### PR TITLE
refactor: ky instance response 타입 변경

### DIFF
--- a/src/apis/auth/apis.ts
+++ b/src/apis/auth/apis.ts
@@ -3,21 +3,17 @@ import api from '@/apis/config/instance';
 import type { LoginPayload, LoginResponse } from './types';
 
 export const postLogin = async (payload: LoginPayload) => {
-  const { data } = await api
-    .post('api/v1/auth/kakao/login', {
-      json: payload,
-    })
-    .json<APIResponse<LoginResponse>>();
+  const { data } = await api.post<LoginResponse>('api/v1/auth/kakao/login', {
+    json: payload,
+  });
 
   return data;
 };
 
 export const postRefresh = async (refreshToken: string) => {
-  const { data } = await api
-    .post('api/v1/auth/refresh', {
-      json: { refreshToken },
-    })
-    .json<APIResponse<LoginResponse>>();
+  const { data } = await api.post<LoginResponse>('api/v1/auth/refresh', {
+    json: { refreshToken },
+  });
 
   return data;
 };

--- a/src/apis/config/instance.ts
+++ b/src/apis/config/instance.ts
@@ -2,7 +2,9 @@ import { retryRequest } from './retryRequest';
 import { setHeader } from './setHeader';
 import ky from 'ky';
 
-const api = ky.create({
+import type { Input, Options } from 'ky/distribution/types/options';
+
+const instance = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_API_URL,
   headers: {
     'Content-Type': 'application/json',
@@ -12,5 +14,13 @@ const api = ky.create({
     afterResponse: [retryRequest],
   },
 });
+
+const api = {
+  get: <T>(url: Input, options?: Options) => instance.get(url, options).json<APIResponse<T>>(),
+  post: <T>(url: Input, options?: Options) => instance.post(url, options).json<APIResponse<T>>(),
+  put: <T>(url: Input, options?: Options) => instance.put(url, options).json<APIResponse<T>>(),
+  delete: <T>(url: Input, options?: Options) =>
+    instance.delete(url, options).json<APIResponse<T>>(),
+};
 
 export default api;

--- a/src/apis/image/apis.ts
+++ b/src/apis/image/apis.ts
@@ -4,23 +4,19 @@ import type { ImagesPayload } from './types';
 import type { ImageObject } from '@/types/Image';
 
 export const getImages = async (imageIds: number[]) => {
-  const { data } = await api
-    .get('api/v1/images', {
-      searchParams: {
-        imageIds: imageIds.join(','),
-      },
-    })
-    .json<APIResponse<{ images: ImageObject[] }>>();
+  const { data } = await api.get<{ images: ImageObject[] }>('api/v1/images', {
+    searchParams: {
+      imageIds: imageIds.join(','),
+    },
+  });
 
   return data;
 };
 
 export const postImages = async (payload: ImagesPayload) => {
-  const { data } = await api
-    .post('api/v1/images', {
-      json: payload,
-    })
-    .json<APIResponse<{ images: ImageObject[] }>>();
+  const { data } = await api.post<{ images: ImageObject[] }>('api/v1/images', {
+    json: payload,
+  });
 
   return data;
 };

--- a/src/apis/place/apis.ts
+++ b/src/apis/place/apis.ts
@@ -4,18 +4,17 @@ import ky from 'ky';
 import type { Place, PlacesAround } from '@/types/place';
 
 export const getPlace = async (id: number) => {
-  const { data } = await api.get(`api/v1/places/${id}`).json<APIResponse<Place>>();
+  const { data } = await api.get<Place>(`api/v1/places/${id}`);
   // const { data } = await ky.get('/db/place.json').json<APIResponse<Place>>();
 
   return data;
 };
 
 export const getPlacesAround = async (params: PlacesAround) => {
-  const { data } = await api
-    .get('api/v1/places/around', {
-      searchParams: { ...params },
-    })
-    .json<APIResponse<{ places: Place[] }>>();
+  const { data } = await api.get<{ places: Place[] }>('api/v1/places/around', {
+    searchParams: { ...params },
+  });
+
   // const { data } = await ky.get('/db/places.json').json<APIResponse<{ places: Place[] }>>();
 
   return data;

--- a/src/apis/review/apis.ts
+++ b/src/apis/review/apis.ts
@@ -2,6 +2,9 @@ import ky from 'ky';
 
 import type { Review } from '@/types/review';
 
+/**
+ * api 나오면 수정
+ */
 export const getReviews = async (placeId: number, size: number, pageParam: number) => {
   const { data } = await ky.get('/db/reviews.json').json<APIResponse<{ reviews: Review[] }>>();
 
@@ -11,6 +14,9 @@ export const getReviews = async (placeId: number, size: number, pageParam: numbe
   };
 };
 
+/**
+ * api 나오면 수정
+ */
 export const getMemberReviews = async (memberId: number, size: number, pageParam: number) => {
   const { data } = await ky.get('/db/reviews.json').json<APIResponse<{ reviews: Review[] }>>();
 


### PR DESCRIPTION
## 💡 이슈
close #61

## 🧑‍💻 작업 사항
<!-- 작업한 내용을 적어주세요. -->
- ky instance response 타입 변경

## 📖 참고 사항
<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요. -->

이제 `.json<APIResponse<RESPONSE_TYPE>>()`을 적지 않고 get, post 등의 제네릭으로 반환 타입을 넣어도 됩니다!

```diff
- const { data } = await api.get(`api/v1/places/${id}`).json<APIResponse<Place>>();
+ const { data } = await api.get<Place>(`api/v1/places/${id}`);
```
